### PR TITLE
Add Dockerfile to compile and package mcjoin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:stretch
+
+COPY . /root/mcjoin
+WORKDIR /root/mcjoin
+RUN apt-get update && apt-get install -y build-essential automake
+RUN ./autogen.sh
+RUN ./configure --prefix=/usr
+RUN make
+
+FROM debian:stretch
+COPY --from=0 /root/mcjoin/mcjoin /usr/bin/mcjoin
+
+CMD [ "/usr/bin/mcjoin" ]


### PR DESCRIPTION
Multistage Dockerfile based on debian:stretch

stage 0: build mcjoin
stage 1: install to /usr/bin/mcjoin