### PR TITLE
update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.11
 RUN apk add --update git build-base automake autoconf
 
 RUN git clone --depth=1 https://github.com/troglobit/mcjoin.git /root/mcjoin
@@ -8,7 +8,7 @@ RUN ./autogen.sh
 RUN ./configure --prefix=/usr
 RUN make
 
-FROM alpine:3.9
-COPY --from=0 /root/mcjoin/mcjoin /usr/bin/mcjoin
+FROM alpine:3.11
+COPY --from=0 /root/mcjoin/src/mcjoin /usr/bin/mcjoin
 
 CMD [ "/usr/bin/mcjoin" ]


### PR DESCRIPTION
* update alpine base image from 3.9 to current 3.11
* change source path when copying over mcjoin binary after build to /root/mcjoin/src/mcjoin

Signed-off-by: Jan Klare <jan.klare@bisdn.de>