### PR TITLE
daemonize: fix setsid conditional after refactoring

### DIFF
--- a/src/daemonize.c
+++ b/src/daemonize.c
@@ -28,12 +28,9 @@ int daemonize(void)
 		_exit(0);
 	}
 
-	/* Starta a new session */
-	if ((rc = setsid())) {
-		if (rc == (pid_t)-1)
-			return -1;
-		_exit(0);
-	}
+	/* Start a new session */
+	if (setsid() == (pid_t)-1)
+		return -1;
 
 	/*
 	 * Old double-fork trick to prevent us from reacquiring


### PR DESCRIPTION
A bug was introduced in 50f7c3047ba8bf759de7df248512ccdbc33eb1bc, where mcjoin
would not daemonise correctly. setsid returns a non-zero value during normal operation, and that causes mcjoin to exit instead.