### PR TITLE
Fix uptime display in old output mode

### DIFF
--- a/src/mcjoin.c
+++ b/src/mcjoin.c
@@ -968,8 +968,9 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	start = time(NULL);
+
 	if (foreground && pres > 1) {
-		start = time(NULL);
 		ttraw();
 		hidecursor();
 	}


### PR DESCRIPTION
The original issue can be reproduced by enabling the "old (plain/ordinary) output" mode:

```console
ubuntu@machine:~$ ./mcjoin -o
Joining (*,225.1.2.3) on br-lan, ifindex: 6, sd: 5
^C*,225.1.2.3: invalid 0     delay 0     gaps 0     reorder 0     dupes 0     bytes 0             packets 0

Total: 0 packets
Uptime: 19010d 09h 31m 50s
```

This is due to the `start` variable not being set in old presentation mode.

The change is to set `start` unconditionally. Resulting output after fix:

```console
ubuntu@machine:~$ ./mcjoin -o
Joining (*,225.1.2.3) on br-lan, ifindex: 6, sd: 5
^C*,225.1.2.3: invalid 0     delay 0     gaps 0     reorder 0     dupes 0     bytes 0             packets 0

Total: 0 packets
Uptime: 2s
```