### PR TITLE
Reduce memory usage (RSS)

### DIFF
--- a/src/mcjoin.c
+++ b/src/mcjoin.c
@@ -689,9 +689,6 @@ int main(int argc, char *argv[])
 	int i, c, rc;
 	size_t ilen;
 
-	for (i = 0; i < MAX_NUM_GROUPS; i++)
-		memset(&groups[i], 0, sizeof(groups[0]));
-
 	ident = progname(argv[0]);
 	while ((c = getopt(argc, argv, "b:c:df:hi:jl:op:st:vw:W:")) != EOF) {
 		switch (c) {
@@ -776,8 +773,10 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (optind == argc)
+	if (optind == argc) {
+		memset(&groups[group_num], 0, sizeof(groups[0]));
 		groups[group_num++].group = strdup(DEFAULT_GROUP);
+	}
 
 	if (!foreground) {
 		if (daemonize()) {
@@ -876,6 +875,7 @@ int main(int argc, char *argv[])
 			}
 
 			DEBUG("Adding (S,G) %s,%s to list ...", source ?: "*", group);
+			memset(&groups[group_num], 0, sizeof(groups[0]));
 			groups[group_num].source  = source;
 			groups[group_num++].group = strdup(group);
 


### PR DESCRIPTION
To save memory usage propose to initialize elements in groups[] only as needed.

Before this patch:
```
pmap -x 41720
41720:   ./src/mcjoin 232.4.4.4+10
Address           Kbytes     RSS   Dirty Mode  Mapping
00005936cba02000       8       8       0 r---- mcjoin
00005936cba04000      24      24       0 r-x-- mcjoin
00005936cba0a000      12      12       0 r---- mcjoin
00005936cba0d000       4       4       4 r---- mcjoin
00005936cba0e000       4       4       4 rw--- mcjoin
00005936cba0f000   19168   19168   19168 rw---   [ anon ]
00005936d0695000     132      52      52 rw---   [ anon ]
000078f514b2e000      12       8       8 rw---   [ anon ]
000078f514b31000     144     144       0 r---- libc.so.6
000078f514b55000    1456    1188       0 r-x-- libc.so.6
000078f514cc1000     312     180       0 r---- libc.so.6
000078f514d0f000      16      16      16 r---- libc.so.6
000078f514d13000       8       8       8 rw--- libc.so.6
000078f514d15000      40      24      24 rw---   [ anon ]
000078f514d58000      16       0       0 r----   [ anon ]
000078f514d5c000       8       4       0 r-x--   [ anon ]
000078f514d5e000       4       4       0 r---- ld-linux-x86-64.so.2
000078f514d5f000     156     156       0 r-x-- ld-linux-x86-64.so.2
000078f514d86000      40      40       0 r---- ld-linux-x86-64.so.2
000078f514d90000       8       8       8 r---- ld-linux-x86-64.so.2
000078f514d92000       8       8       8 rw--- ld-linux-x86-64.so.2
00007ffdedc3d000     132      16      16 rw---   [ stack ]
ffffffffff600000       4       0       0 --x--   [ anon ]
---------------- ------- ------- ------- 
total kB           21716   21076   19316
```

After this patch:
```
pmap  -x 40152
40152:   ./mcjoin 232.4.4.4+10
Address           Kbytes     RSS   Dirty Mode  Mapping
00005beadbc89000       8       8       0 r---- mcjoin
00005beadbc8b000      24      24       0 r-x-- mcjoin
00005beadbc91000      12      12       0 r---- mcjoin
00005beadbc94000       4       4       4 r---- mcjoin
00005beadbc95000       4       4       4 rw--- mcjoin
00005beadbc96000   19168      96      96 rw---   [ anon ]
00005beb00d8f000     132      52      52 rw---   [ anon ]
00007615c4479000      12       8       8 rw---   [ anon ]
00007615c447c000     144     144       0 r---- libc.so.6
00007615c44a0000    1456    1192       0 r-x-- libc.so.6
00007615c460c000     312     140       0 r---- libc.so.6
00007615c465a000      16      16      16 r---- libc.so.6
00007615c465e000       8       8       8 rw--- libc.so.6
00007615c4660000      40      24      24 rw---   [ anon ]
00007615c46a3000      16       0       0 r----   [ anon ]
00007615c46a7000       8       4       0 r-x--   [ anon ]
00007615c46a9000       4       4       0 r---- ld-linux-x86-64.so.2
00007615c46aa000     156     156       0 r-x-- ld-linux-x86-64.so.2
00007615c46d1000      40      40       0 r---- ld-linux-x86-64.so.2
00007615c46db000       8       8       8 r---- ld-linux-x86-64.so.2
00007615c46dd000       8       8       8 rw--- ld-linux-x86-64.so.2
00007fff349d3000     132      12      12 rw---   [ stack ]
ffffffffff600000       4       0       0 --x--   [ anon ]
---------------- ------- ------- ------- 
total kB           21716    1964     240
```